### PR TITLE
Make xxhash optional

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "asset-hash",
-  "version": "2.2.8",
+  "version": "2.2.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,9 @@
     "@babel/runtime": "^7.3.1",
     "big.js": "^5.2.2",
     "core-js": "^2.6.3",
-    "metrohash": "^2.5.1",
+    "metrohash": "^2.5.1"
+  },
+  "optionalDependencies": {
     "xxhash": "^0.2.4"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,12 @@ import { createReadStream } from "fs"
 import { extname } from "path"
 import BigInt from "big.js"
 import { MetroHash128, MetroHash64 } from "metrohash"
-import { default as XXHash32, XXHash64 } from "xxhash"
+
+// optional xxhash module
+let xxhash = null
+try { xxhash = require("xxhash") } catch (e) {}
+const XXHash32 = xxhash ? xxhash : null
+const XXHash64 = xxhash ? xxhash.XXHash64 : null
 
 const DEFAULT_HASH = "metrohash128"
 const DEFAULT_ENCODING = "base52"
@@ -100,8 +105,14 @@ export function createHasher(hash) {
   let hasher
 
   if (hash === "xxhash32") {
+    if (!XXHash32) {
+      throw new Error("Install xxhash module to use xxhash32 hasher")
+    }
     hasher = new XXHash32(XXHASH_CONSTRUCT)
   } else if (hash === "xxhash64") {
+    if (!XXHash64) {
+      throw new Error("Install xxhash module to use xxhash64 hasher")
+    }
     hasher = new XXHash64(XXHASH_CONSTRUCT)
   } else if (hash === "metrohash64") {
     hasher = new MetroHash64()


### PR DESCRIPTION
Make xxhash optional

as discussed here: https://github.com/sebastian-software/asset-hash/issues/1

Changes:

- moved xxhash to optionalDependencies
- replaced static import with require() and try/catch wrapper
- throw error if requested xxhash32/64 hash but xxhash is not available

Tests are passing